### PR TITLE
Change seconds amount for error for image

### DIFF
--- a/modules/auth/components/Avatar.tsx
+++ b/modules/auth/components/Avatar.tsx
@@ -22,7 +22,7 @@ const Avatar: NextPage<Avatar> = (props) => {
         setAvatarUrl(url);
       } catch (err: any) {
         if (err.message === "The resource was not found") {
-          showAlert("Oops, the image was not found.", 1.5);
+          showAlert("Oops, the image was not found.", 2);
         } else console.log("Error downloading image: ", err.message);
       }
     };


### PR DESCRIPTION
Here, I changed the second's amount for the 404 not found error for profile pictures warning. 